### PR TITLE
fix: favor `globalThis.crypto` over `require('crypto')`

### DIFF
--- a/packages/pg/lib/crypto/utils-webcrypto.js
+++ b/packages/pg/lib/crypto/utils-webcrypto.js
@@ -1,5 +1,3 @@
-const nodeCrypto = require('crypto')
-
 module.exports = {
   postgresMd5PasswordHash,
   randomBytes,
@@ -13,7 +11,7 @@ module.exports = {
  * The Web Crypto API - grabbed from the Node.js library or the global
  * @type Crypto
  */
-const webCrypto = nodeCrypto.webcrypto || globalThis.crypto
+const webCrypto = globalThis.crypto || require('crypto').webcrypto
 /**
  * The SubtleCrypto API for low level crypto operations.
  * @type SubtleCrypto
@@ -32,7 +30,7 @@ function randomBytes(length) {
 
 async function md5(string) {
   try {
-    return nodeCrypto.createHash('md5').update(string, 'utf-8').digest('hex')
+    return require('crypto').createHash('md5').update(string, 'utf-8').digest('hex')
   } catch (e) {
     // `createHash()` failed so we are probably not in Node.js, use the WebCrypto API instead.
     // Note that the MD5 algorithm on WebCrypto is not available in Node.js.


### PR DESCRIPTION
In runtimes outside of Node.js, `require()` is not defined.

So we should favor `globalThis.crypto` and only fallback to `require('crypto')` for older versions of Node.js

https://nodejs.org/api/globals.html#crypto_1

This is following up on the work from PR #3033.